### PR TITLE
[k8s] force dd-agent to use kubelet for tagger requests

### DIFF
--- a/roles/kubernetes/files/etc/systemd/system/datadog-agent.service.d/10-kubernetes.conf
+++ b/roles/kubernetes/files/etc/systemd/system/datadog-agent.service.d/10-kubernetes.conf
@@ -1,0 +1,4 @@
+[Service]
+# force dd-agent's tagger to talk to kubelet for tags
+# Workaround for https://github.com/DataDog/datadog-agent/pull/7583
+Environment=KUBERNETES=true

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -82,6 +82,17 @@
     dest: /etc/systemd/system/kubelet.service.d/10-kubelet-common.conf
     mode: 0644
 
+- name: make dd-agent systemd drop-in directory
+  file:
+    name: /etc/systemd/system/datadog-agent.service.d/
+    state: directory
+
+- name: copy dd-agent systemd drop-in
+  copy:
+    src: etc/systemd/datadog-agent.service.d/10-kubernetes.conf
+    dest: /etc/systemd/datadog-agent.service.d/10-kubernetes.conf
+    mode: 0644
+
 - name: copy component configurations
   copy:
     src: etc/sysconfig/{{ item }}


### PR DESCRIPTION
Force the Datadog Agent to believe it's inside a Kubernetes cluster.

For some reason, the tagger will only talk to the kubelet on a host if the environment variable `KUBERNETES` is set to a non-empty string.

This change was introduced in https://github.com/DataDog/datadog-agent/pull/7583 to mitigate a duplicate tags issue, however it has the side effect of removing the ability for an agent living outside of Kubernetes to access tags on the kubelet on the same host, even though the `datadog.yaml` configuration options are set.

Validation after the change:
```
$ datadog-agent tagger-list
=== Entity container_id://480b7ee0ebd572ee7737786d98f5cc2f66684135426a664760a6a503b59e3917 ===
== Source docker ==
Tags: [container_id:480b7ee0ebd572ee7737786d98f5cc2f66684135426a664760a6a503b59e3917 container_name:k8s_metrics-server_metrics-server-79559c79cc-mt2wg_kube-system_fc331c55-df31-4c13-b7c1-4782b202ad82_0 docker_image:k8s.gcr.io/metrics-server/metrics-server:v0.5.0 image_name:k8s.gcr.io/metrics-server/metrics-server image_tag:v0.5.0 short_image:metrics-server]
== Source kubelet ==
Tags: [container_id:480b7ee0ebd572ee7737786d98f5cc2f66684135426a664760a6a503b59e3917 display_container_name:metrics-server_metrics-server-79559c79cc-mt2wg image_name:k8s.gcr.io/metrics-server/metrics-server image_tag:v0.5.0 kube_container_name:metrics-server kube_deployment:metrics-server kube_namespace:kube-system kube_ownerref_kind:replicaset kube_ownerref_name:metrics-server-79559c79cc kube_replica_set:metrics-server-79559c79cc pod_name:metrics-server-79559c79cc-mt2wg pod_phase:running short_image:metrics-server]
===

=== Entity kubernetes_pod_uid://fc331c55-df31-4c13-b7c1-4782b202ad82 ===
== Source docker ==
Tags: []
== Source kubelet ==
Tags: [kube_deployment:metrics-server kube_namespace:kube-system kube_ownerref_kind:replicaset kube_ownerref_name:metrics-server-79559c79cc kube_replica_set:metrics-server-79559c79cc pod_name:metrics-server-79559c79cc-mt2wg pod_phase:running]
===
```

Prior to this change, no `kubelet` tags would exist.

Note: it's possible that there's another hidden issue shown above - the same pod is autodiscovered twice: once by the docker AD provider, and another by the kubelet AD provider.
This *shouldn't* be an issue, considering the tagger is a key/value map, so having it duplicated might be beneficial since we'll get the kubelet tags in the docker container metrics and the docker tags in the kubelet metrics. (i.e. `docker.cpu.user` will have kubelet tags available)