### PR TITLE
[system-base] Install linux kernel 5.10 from amazon-linux-extras

### DIFF
--- a/roles/system-base/tasks/Amazon.yml
+++ b/roles/system-base/tasks/Amazon.yml
@@ -1,46 +1,13 @@
 ---
 #### Amazon Linux Specific Tweaks ####
 
-# Note: we can't just rpm install elrepo because it requires glibc=2.17, whereas we have glibc 2.26
-# ¯\_(ツ)_/¯
-- name: add elrepo-kernel repository
-  yum_repository:
-    name: elrepo-kernel
-    enabled: no
-    description: ELRepo.org Community Enterprise Linux Kernel Repository - el7
-    mirrorlist: http://mirrors.elrepo.org/mirrors-elrepo-kernel.el7
-    baseurl: http://elrepo.org/linux/kernel/el7/$basearch/
-    gpgcheck: no
-
-- name: Remove kernel-headers and kernel-tools
-  yum:
-    name:
-      - kernel-headers
-      - kernel-tools
-    state: absent
-
-- name: install kernel-ml >= {{ kernel_min }}
-  yum:
-    name:
-      - "kernel-ml >= {{ kernel_min }}"
-      - "kernel-ml-devel >= {{ kernel_min }}"
-      - "kernel-ml-headers >= {{ kernel_min }}"
-      - "kernel-ml-tools-libs-devel >= {{ kernel_min }}"
-    enablerepo: elrepo-kernel
-    state: latest
-
-- name: update grub to point to latest kernel
-  shell:
-    cmd: |
-      grub2-set-default 0
-      grub2-mkconfig -o /boot/grub2/grub.cfg
-
 - name: enable epel and bcc via amazon-linux-extras
   # Amazon-linux-extras is required to enable epel
   # noqa 301 305
   shell: |
-    amazon-linux-extras enable epel
-    amazon-linux-extras enable BCC
+    amazon-linux-extras install -y epel
+    amazon-linux-extras install -y BCC
+    amazon-linux-extras install -y kernel-{{ kernel_min }}
 
 
 # Amazon SSM agent is unnecessary, we have consul and ansible.


### PR DESCRIPTION
`kernel_min: "5.10"` as shown here: https://github.com/nxtlytics/ivy-ami-bakery/blob/master/roles/system-base/defaults/main.yml#L3 is now available via `amazon-linux-extras`, see here: https://github.com/awslabs/amazon-eks-ami/blob/master/scripts/upgrade_kernel.sh#L31

### Before `amazon-linux-extras enable kernel-5.10`

```shell
$ grep kernel /etc/yum.repos.d/amzn2-*
/etc/yum.repos.d/amzn2-extras.repo:[amzn2extra-kernel-ng-source]
/etc/yum.repos.d/amzn2-extras.repo:name = Amazon Extras source repo for kernel-ng
/etc/yum.repos.d/amzn2-extras.repo:mirrorlist = $awsproto://$amazonlinux.$awsregion.$awsdomain/$releasever/extras/kernel-ng/latest/SRPMS/mirror.list
/etc/yum.repos.d/amzn2-extras.repo:[amzn2extra-kernel-ng-debuginfo]
/etc/yum.repos.d/amzn2-extras.repo:name = Amazon Extras debuginfo repo for kernel-ng
/etc/yum.repos.d/amzn2-extras.repo:mirrorlist = $awsproto://$amazonlinux.$awsregion.$awsdomain/$releasever/extras/kernel-ng/latest/debuginfo/$basearch/mirror.list
/etc/yum.repos.d/amzn2-extras.repo:[amzn2extra-kernel-ng]
/etc/yum.repos.d/amzn2-extras.repo:name = Amazon Extras repo for kernel-ng
/etc/yum.repos.d/amzn2-extras.repo:mirrorlist = $awsproto://$amazonlinux.$awsregion.$awsdomain/$releasever/extras/kernel-ng/latest/$basearch/mirror.list
```

### After `amazon-linux-extras enable kernel-5.10`

```shell
$ grep 'kernel' /etc/yum.repos.d/amzn2-*
/etc/yum.repos.d/amzn2-extras.repo:[amzn2extra-kernel-ng-source]
/etc/yum.repos.d/amzn2-extras.repo:name = Amazon Extras source repo for kernel-ng
/etc/yum.repos.d/amzn2-extras.repo:mirrorlist = $awsproto://$amazonlinux.$awsregion.$awsdomain/$releasever/extras/kernel-ng/latest/SRPMS/mirror.list
/etc/yum.repos.d/amzn2-extras.repo:[amzn2extra-kernel-ng-debuginfo]
/etc/yum.repos.d/amzn2-extras.repo:name = Amazon Extras debuginfo repo for kernel-ng
/etc/yum.repos.d/amzn2-extras.repo:mirrorlist = $awsproto://$amazonlinux.$awsregion.$awsdomain/$releasever/extras/kernel-ng/latest/debuginfo/$basearch/mirror.list
/etc/yum.repos.d/amzn2-extras.repo:[amzn2extra-kernel-ng]
/etc/yum.repos.d/amzn2-extras.repo:name = Amazon Extras repo for kernel-ng
/etc/yum.repos.d/amzn2-extras.repo:mirrorlist = $awsproto://$amazonlinux.$awsregion.$awsdomain/$releasever/extras/kernel-ng/latest/$basearch/mirror.list
/etc/yum.repos.d/amzn2-extras.repo:[amzn2extra-kernel-5.10-source]
/etc/yum.repos.d/amzn2-extras.repo:name = Amazon Extras source repo for kernel-5.10
/etc/yum.repos.d/amzn2-extras.repo:mirrorlist = $awsproto://$amazonlinux.$awsregion.$awsdomain/$releasever/extras/kernel-5.10/latest/SRPMS/mirror.list
/etc/yum.repos.d/amzn2-extras.repo:[amzn2extra-kernel-5.10-debuginfo]
/etc/yum.repos.d/amzn2-extras.repo:name = Amazon Extras debuginfo repo for kernel-5.10
/etc/yum.repos.d/amzn2-extras.repo:mirrorlist = $awsproto://$amazonlinux.$awsregion.$awsdomain/$releasever/extras/kernel-5.10/latest/debuginfo/$basearch/mirror.list
/etc/yum.repos.d/amzn2-extras.repo:[amzn2extra-kernel-5.10]
/etc/yum.repos.d/amzn2-extras.repo:name = Amazon Extras repo for kernel-5.10
/etc/yum.repos.d/amzn2-extras.repo:mirrorlist = $awsproto://$amazonlinux.$awsregion.$awsdomain/$releasever/extras/kernel-5.10/latest/$basearch/mirror.list
```

### Packages in repo

```shell
$ yum --disablerepo="*" --enablerepo="amzn2extra-kernel-5.10" list available
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Available Packages
bpftool.x86_64                                                  5.10.75-79.358.amzn2                          amzn2extra-kernel-5.10
kernel.x86_64                                                   5.10.75-79.358.amzn2                          amzn2extra-kernel-5.10
kernel-devel.x86_64                                             5.10.75-79.358.amzn2                          amzn2extra-kernel-5.10
kernel-headers.x86_64                                           5.10.75-79.358.amzn2                          amzn2extra-kernel-5.10
kernel-livepatch-5.10.50-44.131.x86_64                          1.0-0.amzn2                                   amzn2extra-kernel-5.10
kernel-livepatch-5.10.50-44.132.x86_64                          1.0-0.amzn2                                   amzn2extra-kernel-5.10
kernel-livepatch-5.10.59-52.142.x86_64                          1.0-0.amzn2                                   amzn2extra-kernel-5.10
kernel-livepatch-5.10.62-55.141.x86_64                          1.0-0.amzn2                                   amzn2extra-kernel-5.10
kernel-livepatch-5.10.68-62.173.x86_64                          1.0-0.amzn2                                   amzn2extra-kernel-5.10
kernel-livepatch-5.10.75-79.358.x86_64                          1.0-0.amzn2                                   amzn2extra-kernel-5.10
kernel-tools.x86_64                                             5.10.75-79.358.amzn2                          amzn2extra-kernel-5.10
kernel-tools-devel.x86_64                                       5.10.75-79.358.amzn2                          amzn2extra-kernel-5.10
perf.x86_64                                                     5.10.75-79.358.amzn2                          amzn2extra-kernel-5.10
python-perf.x86_64                                              5.10.75-79.358.amzn2                          amzn2extra-kernel-5.10
```