### PR TITLE
Bumping e2d version to 0.4.14-nxt+6

### DIFF
--- a/roles/kubernetes/defaults/main.yml
+++ b/roles/kubernetes/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # e2d version
-e2d_version: "0.4.14-nxt+4"
+e2d_version: "0.4.14-nxt+6"
 # etcd version (for etcdctl)
 etcd_version: "3.5.0"
 # default kubernetes version - should match (close-ish) the version of the masters


### PR DESCRIPTION
This version looks for `DeviceIndex: 0` and no longer
looks for `NetworkInterfaces[0]`