### PR TITLE
[system-base] Install yum-plugin-versionlock and use it to lock pritunl and datadog-agent

### DIFF
--- a/roles/pritunl/tasks/main.yml
+++ b/roles/pritunl/tasks/main.yml
@@ -14,6 +14,12 @@
       - mongodb-org
     state: present
 
+- name: lock package to a version
+  shell:
+    cmd: yum versionlock add {{ item }}
+  loop:
+    - "pritunl-{{ pritunl_version }}"
+
 - name: disable pritunl and mongod on first boot
   systemd:
     name: "{{ item }}"

--- a/roles/system-base/files/opt/ivy/bash_functions.sh
+++ b/roles/system-base/files/opt/ivy/bash_functions.sh
@@ -206,7 +206,11 @@ function setup_docker_storage() {
   sed -i '/${DEVICE}/d' /etc/fstab
   echo "${FSTAB}" >> /etc/fstab
 
-  systemctl enable --now docker
+  if check_systemctl_status 'docker'; then
+    systemctl restart docker
+  else
+    systemctl enable --now docker
+  fi
 }
 
 function update_env() {
@@ -253,6 +257,14 @@ function retry() {
     warn "Waiting for '${*}' to succeed, sleeping 5 seconds"
     sleep 5
   done
+}
+
+function check_systemctl_status() {
+  local UNIT="${1}"
+  if ! grep -q 'active' <(systemctl is-active "${UNIT}"); then
+    warn "${UNIT} status is NOT: active"
+    return 1
+  fi
 }
 
 case "$(get_cloud)" in

--- a/roles/system-base/files/opt/ivy/bash_lib/k8s.sh
+++ b/roles/system-base/files/opt/ivy/bash_lib/k8s.sh
@@ -171,14 +171,6 @@ function get_k8s_node_status() {
     -l "${NODE_LABEL}" | grep -v NAME | awk '{ print $2 }'
 }
 
-function check_systemctl_status() {
-  local UNIT="${1}"
-  if ! grep -q 'active' <(systemctl is-active "${UNIT}"); then
-    warn "${UNIT} status is NOT: active"
-    return 1
-  fi
-}
-
 function check_dd_features() {
   local FEATURES_AS_STRING="${1}"
   declare -a FEATURES

--- a/roles/system-base/tasks/main.yml
+++ b/roles/system-base/tasks/main.yml
@@ -160,11 +160,18 @@
       - xfsprogs
       - tcpdump
       - systemd-devel
+      - yum-plugin-versionlock
     state: latest
     enablerepo:
       - datadog
       - epel
       - newrelic-infra
+
+- name: lock package to a version
+  shell:
+    cmd: yum versionlock add {{ item }}
+  loop:
+    - "datadog-agent-{{ dd_version }}"
 
 - name: add datadog agent to the systemd-journal group
   user:


### PR DESCRIPTION
[bash_functions.sh] function setup_docker_storage now enables or restarts docker depending on whether
docker is already running or not